### PR TITLE
Patches to make this work on a WM

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Currently not tested, JamSpell is not supported. **Please do not open issues abo
 ## Authors
 - [@epassaro](https://github.com/epassaro)
 - [@agostinaf](https://github.com/agostinaf)
-- [@fitosb](https://github.com/fitosb)
+- [@fitosb](https://github.com/asimazbunzel)
 
 ## License
 ![This software is released under the MIT license](https://img.shields.io/github/license/epassaro/scr2ocr)

--- a/scr2ocr.py
+++ b/scr2ocr.py
@@ -57,6 +57,7 @@ if __name__ == "__main__":
     root = Tk()
     root.title("scr2ocr")
     root.geometry(f"{WIDTH}x{HEIGHT}")
+    root.attributes("-type", "utility")
 
     # Linux transparency workaround, try `root.wm_attributes('-transparentcolor', root["bg"])` on Windows
     root.wait_visibility(root)


### PR DESCRIPTION
Change some attributes (`root.attributes("-type", "utility")`) of the Tk class in order to make it
a floating window. This is needed in a tiling windows manager like i3, dwm, etc...

As a side note, the compositor should also have an opacity rule to have some transparency.
E.g., in the picom compositor I added the following rule: opacity-rule = ["50:name = 'scr2ocr'",]